### PR TITLE
Missing header for _rdtsc() function when compiling with GCC

### DIFF
--- a/synk/loadimba.cpp
+++ b/synk/loadimba.cpp
@@ -33,6 +33,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <omp.h>
 #include <stdio.h>
 
+#ifdef __GNUC__
+#include <x86intrin.h>
+#endif
+
 #include "cpuid.h"
 #include "loadimba.hpp"
 


### PR DESCRIPTION
I need x86intrin.h to be included for _rdtsc() when compiling with GCC.